### PR TITLE
Ensure the bin directory exists before checking empty

### DIFF
--- a/src/Composer/Installer/LibraryInstaller.php
+++ b/src/Composer/Installer/LibraryInstaller.php
@@ -268,7 +268,7 @@ class LibraryInstaller implements InstallerInterface
         }
 
         // attempt removing the bin dir in case it is left empty
-        if ($this->filesystem->isDirEmpty($this->binDir)) {
+        if ((is_dir($this->binDir)) && ($this->filesystem->isDirEmpty($this->binDir))) {
             @rmdir($this->binDir);
         }
     }


### PR DESCRIPTION
Line 130 has similar logic so avoided doing the check withiin `isDirEmpty()`
